### PR TITLE
Fix linux keyboard to support most portable-keys

### DIFF
--- a/src/Andama/mainwindow.cpp
+++ b/src/Andama/mainwindow.cpp
@@ -124,16 +124,7 @@ bool MainWindow::eventFilter(QObject *watched, QEvent* e)
         //sta windows to ke->nativeVirtualKey() epistrefei panta kapoio key
         //enw sto mac, gia shift,cmd,alt,ctrl,CAPS to ke->nativeVirtualKey() epistrefei 0
 
-#ifdef Q_OS_LINUX
-        portableVKey natPKey;
-        if (ke->nativeVirtualKey() >= 0x30 && ke->nativeVirtualKey() <= 0x5A){
-           natPKey = Keyboard::getPortableVKey(ke->nativeVirtualKey(), ke->key());
-        } else {
-           natPKey = Keyboard::getPortableVKey(ke->key(), ke->nativeVirtualKey());
-        }
-#else
         portableVKey natPKey = Keyboard::getPortableVKey(ke->nativeVirtualKey(),ke->key());
-#endif
 
         portableKeyboardModifier modPKey =  Keyboard::getPortableModifier(ke->key());
 
@@ -959,7 +950,7 @@ void MainWindow::mymessageRecieved(const clientServerProtocol *client, const int
 
 //click sto koumpi syndesis se apomakrismeno ypologisti
 void MainWindow::on_btnConnectToRemoteClient_clicked()
-{   
+{
     //efoson exei symplirwthei to remote ID kai remote password
     //apostelw to aitima syndesis
     if(ui->txtRemotePCID->text().size() > 0 && ui->txtRemotePassword->text().size() > 0){

--- a/src/Andama/mousekeyb/Keyboard.h
+++ b/src/Andama/mousekeyb/Keyboard.h
@@ -51,7 +51,7 @@ enum portableVKey
     PVK_D = 0x044,
     PVK_E = 0x045,
     PVK_F = 0x046,
-    PVK_G =	0x047,
+    PVK_G = 0x047,
     PVK_H = 0x048,
     PVK_I = 0x049,
     PVK_J = 0x04A,

--- a/src/Andama/mousekeyb/KeyboardLinux.cpp
+++ b/src/Andama/mousekeyb/KeyboardLinux.cpp
@@ -21,9 +21,10 @@
 #include "Keyboard.h"
 
 #ifdef Q_OS_LINUX
-#define XK_LATIN1;
-#define XK_MISCELLANY;
+#define XK_LATIN1
+#define XK_MISCELLANY
 #include <X11/keysymdef.h>
+#include <X11/XF86keysym.h>
 #include <X11/extensions/XTest.h>
 
 void Keyboard::keyPress(int key, int modifiers)
@@ -47,486 +48,375 @@ void Keyboard::keyRelease(int key, int modifiers)
 
 portableVKey Keyboard::getPortableVKey(int key, int qtkey)
 {
-    switch (key)
+    switch (qtkey)
     {
-    case XK_equal:
-return portableVKey::PVK_EQUAL;
-break;
-    case XK_minus:
-        return portableVKey::PVK_MINUS;
-        break;
-
-    case XK_bracketright:
-return portableVKey::PVK_RIGHT_BRACKET;
-break;
-    case XK_bracketleft:
-return portableVKey::PVK_LEFT_BRACKET;
-break;
-    case XK_quotedbl:
-        return portableVKey::PVK_QUOTE;
-        break;
-    case XK_Shift_L:
-        return portableVKey::PVK_SHIFT;
-        break;
-    case XK_Control_L:
-        return portableVKey::PVK_CONTROL;
-        break;
-    case XK_Alt_L:
-        return  portableVKey::PVK_ALT;
-        break;
-    case XK_semicolon:
-return portableVKey::PVK_SEMICOLON;
-break;
-    case XK_backslash:
-        return portableVKey::PVK_BACKSLASH;
-        break;
-    case XK_comma:
-        return portableVKey::PVK_COMMA;
-        break;
-    case XK_slash:
-        return portableVKey::PVK_SLASH;
-        break;
-    case XK_period:
-        return portableVKey::PVK_PERIOD;
-        break;
-    case XK_grave:
-        return portableVKey::PVK_GRAVE;
-        break;
-
-    case XK_KP_Decimal:
-    return portableVKey::PVK_DECIMAL;
-    break;
-    case XK_KP_Multiply:
-    return portableVKey::PVK_MULTIPLY;
-    break;
-    case XK_KP_Add:
-    return portableVKey::PVK_ADD;
-    break;
-    //case kVK_ANSI_KeypadClear:
-    //return portableVKey::PVK_KEYPAD_CLEAR;
-    //break;
-    case XK_KP_Divide:
-    return portableVKey::PVK_KEYPAD_DIVIDE;
-    break;
-    //case kVK_ANSI_KeypadEnter:
-    //return portableVKey::PVK_KEYPAD_ENTER;
-    //break;
-    case XK_KP_Subtract:
-    return portableVKey::PVK_KEYPAD_MINUS;
-    break;
-    //case kVK_ANSI_KeypadEquals:
-    //return portableVKey::PVK_KEYPAD_EQUALS;
-    //break;
-
-    case XK_KP_0:
-        return portableVKey::PVK_NUMPAD0;
-        break;
-    case XK_KP_1:
-        return portableVKey::PVK_NUMPAD1;
-        break;
-    case XK_KP_2:
-        return portableVKey::PVK_NUMPAD2;
-        break;
-    case XK_KP_3:
-        return portableVKey::PVK_NUMPAD3;
-        break;
-    case XK_KP_4:
-        return portableVKey::PVK_NUMPAD4;
-        break;
-    case XK_KP_5:
-        return portableVKey::PVK_NUMPAD5;
-        break;
-    case XK_KP_6:
-        return portableVKey::PVK_NUMPAD6;
-        break;
-    case XK_KP_7:
-        return portableVKey::PVK_NUMPAD7;
-        break;
-    case XK_KP_8:
-        return portableVKey::PVK_NUMPAD8;
-        break;
-    case XK_KP_9:
-        return portableVKey::PVK_NUMPAD9;
-        break;
-
-    case XK_Return:
-        return portableVKey::PVK_RETURN;
-        break;
-    case XK_Tab:
-        return portableVKey::PVK_TAB;
-        break;
-    case XK_space:
+    case Qt::Key_Space:
         return portableVKey::PVK_SPACE;
-        break;
-    case XK_BackSpace:
-        return portableVKey::PVK_BACK;
-        break;
-    case XK_Escape:
-        return portableVKey::PVK_ESCAPE;
-        break;
-    case XK_Caps_Lock:
+    case Qt::Key_Alt:
+        return portableVKey::PVK_ALT;
+    case Qt::Key_Meta:
+        return portableVKey::PVK_LWIN;
+    case Qt::Key_Multi_key:
+        return portableVKey::PVK_RWIN;
+    case Qt::Key_Control:
+        return portableVKey::PVK_CONTROL;
+    case Qt::Key_Shift:
+        return portableVKey::PVK_SHIFT;
+    case Qt::Key_CapsLock:
         return portableVKey::PVK_CAPSLOCK;
-        break;
-    case XK_F17:
-        return portableVKey::PVK_F17;
-        break;
-    //case portableVKey::PVK_VOLUME_UP:
-    //    return kVK_VolumeUp;
-    //    break;
-    //case portableVKey::PVK_VOLUME_DOWN:
-    //    return kVK_VolumeDown;
-    //    break;
-    //case portableVKey::PVK_VOLUME_MUTE:
-    //    return kVK_Mute;
-    //    break;
-    case XK_F18:
-        return portableVKey::PVK_F18;
-        break;
-    case XK_F19:
-        return portableVKey::PVK_F19;
-        break;
-    case XK_F20:
-        return portableVKey::PVK_F20;
-        break;
-    case XK_F5:
-        return portableVKey::PVK_F5;
-        break;
-    case XK_F6:
-        return portableVKey::PVK_F6;
-        break;
-    case XK_F7:
-         return portableVKey::PVK_F7;
-        break;
-    case XK_F3:
-        return portableVKey::PVK_F3;
-        break;
-    case XK_F8:
-        return portableVKey::PVK_F8;
-        break;
-    case XK_F9:
-        return portableVKey::PVK_F9;
-        break;
-    case XK_F11:
-        return portableVKey::PVK_F11;
-        break;
-    case XK_F13:
-        return portableVKey::PVK_F13;
-        break;
-    case XK_F16:
-        return portableVKey::PVK_F16;
-        break;
-    case XK_F14:
-        return portableVKey::PVK_F14;
-        break;
-    case XK_F10:
-        return portableVKey::PVK_F10;
-        break;
-    case XK_F12:
-        return portableVKey::PVK_F12;
-        break;
-    case XK_F15:
-        return portableVKey::PVK_F15;
-        break;
-    case XK_Help:
-        return portableVKey::PVK_HELP;
-        break;
-    case XK_Home:
-        return portableVKey::PVK_HOME;
-        break;
-    case XK_Page_Up:
-        return portableVKey::PVK_PAGE_UP;
-        break;
-    case XK_Delete:
-        return portableVKey::PVK_DELETE; // ?
-        break;
-    case XK_F4:
-        return portableVKey::PVK_F4;
-        break;
-    case XK_End:
-        return portableVKey::PVK_END;
-        break;
-    case XK_F2:
-        return portableVKey::PVK_F2;
-        break;
-    case XK_Page_Down:
-        return portableVKey::PVK_PAGE_DOWN;
-        break;
-    case  XK_F1:
-        return portableVKey::PVK_F1;
-        break;
-    case XK_Left:
+    case Qt::Key_Tab:
+        return portableVKey::PVK_TAB;
+    case Qt::Key_Escape:
+        return portableVKey::PVK_ESCAPE;
+    case Qt::Key_Backspace:
+        return portableVKey::PVK_BACK;
+    case Qt::Key_Enter:
+    case Qt::Key_Return:
+        return portableVKey::PVK_RETURN;
+
+    case Qt::Key_Left:
         return portableVKey::PVK_LEFT;
-        break;
-    case XK_Right:
+    case Qt::Key_Right:
         return portableVKey::PVK_RIGHT;
-        break;
-    case XK_Down:
+    case Qt::Key_Up:
+        return portableVKey::PVK_UP;
+    case Qt::Key_Down:
         return portableVKey::PVK_DOWN;
-        break;
-    case XK_Up:
-        return  portableVKey::PVK_UP;
-        break;
-    case XK_Num_Lock:
-    return portableVKey::PVK_NUMLOCK; //TODO: den paizei
-    break;
-    case XK_Insert:
+
+    case Qt::Key_NumLock:
+        return portableVKey::PVK_NUMLOCK;
+    case Qt::Key_0:
+        return portableVKey::PVK_NUMPAD0;
+    case Qt::Key_1:
+        return portableVKey::PVK_NUMPAD1;
+    case Qt::Key_2:
+        return portableVKey::PVK_NUMPAD2;
+    case Qt::Key_3:
+        return portableVKey::PVK_NUMPAD3;
+    case Qt::Key_4:
+        return portableVKey::PVK_NUMPAD4;
+    case Qt::Key_5:
+        return portableVKey::PVK_NUMPAD5;
+    case Qt::Key_6:
+        return portableVKey::PVK_NUMPAD6;
+    case Qt::Key_7:
+        return portableVKey::PVK_NUMPAD7;
+    case Qt::Key_8:
+        return portableVKey::PVK_NUMPAD8;
+    case Qt::Key_9:
+        return portableVKey::PVK_NUMPAD9;
+
+    case Qt::Key_Equal:
+        return portableVKey::PVK_EQUAL;
+    case Qt::Key_Plus:
+        return portableVKey::PVK_ADD;
+    case Qt::Key_Minus:
+        return portableVKey::PVK_MINUS;
+    case Qt::Key_multiply:
+    case Qt::Key_Asterisk:
+        return portableVKey::PVK_MULTIPLY;
+    case Qt::Key_division:
+    case Qt::Key_Slash:
+        return portableVKey::PVK_SLASH;
+    case Qt::Key_BracketLeft:
+        return portableVKey::PVK_LEFT_BRACKET;
+    case Qt::Key_BracketRight:
+        return portableVKey::PVK_RIGHT_BRACKET;
+    case Qt::Key_Backslash:
+        return portableVKey::PVK_BACKSLASH;
+
+    case Qt::Key_Semicolon:
+        return portableVKey::PVK_SEMICOLON;
+    case Qt::Key_Comma:
+        return portableVKey::PVK_COMMA;
+    case Qt::Key_Period:
+        return portableVKey::PVK_PERIOD;
+    case Qt::Key_QuoteDbl:
+        return portableVKey::PVK_QUOTE;
+
+    case Qt::Key_Insert:
         return portableVKey::PVK_INSERT;
-        break;
-    //case portableVKey::PVK_LWIN:
-    //case portableVKey::PVK_RWIN:
-    //    return kVK_Control;
-    //    break;
+    case Qt::Key_Delete:
+        return portableVKey::PVK_DELETE;
+    case Qt::Key_Home:
+        return portableVKey::PVK_HOME;
+    case Qt::Key_End:
+        return portableVKey::PVK_END;
+    case Qt::Key_PageUp:
+        return portableVKey::PVK_PAGE_UP;
+    case Qt::Key_PageDown:
+        return portableVKey::PVK_PAGE_DOWN;
+
+    case Qt::Key_F1:
+        return portableVKey::PVK_F1;
+    case Qt::Key_F2:
+        return portableVKey::PVK_F2;
+    case Qt::Key_F3:
+        return portableVKey::PVK_F3;
+    case Qt::Key_F4:
+        return portableVKey::PVK_F4;
+    case Qt::Key_F5:
+        return portableVKey::PVK_F5;
+    case Qt::Key_F6:
+        return portableVKey::PVK_F6;
+    case Qt::Key_F7:
+        return portableVKey::PVK_F7;
+    case Qt::Key_F8:
+        return portableVKey::PVK_F8;
+    case Qt::Key_F9:
+        return portableVKey::PVK_F9;
+    case Qt::Key_F10:
+        return portableVKey::PVK_F10;
+    case Qt::Key_F11:
+        return portableVKey::PVK_F11;
+    case Qt::Key_F12:
+        return portableVKey::PVK_F12;
+    case Qt::Key_F13:
+        return portableVKey::PVK_F13;
+    case Qt::Key_F14:
+        return portableVKey::PVK_F14;
+    case Qt::Key_F15:
+        return portableVKey::PVK_F15;
+    case Qt::Key_F16:
+        return portableVKey::PVK_F16;
+    case Qt::Key_F17:
+        return portableVKey::PVK_F17;
+    case Qt::Key_F18:
+        return portableVKey::PVK_F18;
+    case Qt::Key_F19:
+        return portableVKey::PVK_F19;
+    case Qt::Key_F20:
+        return portableVKey::PVK_F20;
+
+    case Qt::Key_VolumeUp:
+        return portableVKey::PVK_VOLUME_UP;
+    case Qt::Key_VolumeDown:
+        return portableVKey::PVK_VOLUME_DOWN;
+    case Qt::Key_VolumeMute:
+        return portableVKey::PVK_VOLUME_MUTE;
+
+    case Qt::Key_Help:
+        return portableVKey::PVK_HELP;
+    case Qt::Key_QuoteLeft:
+        return portableVKey::PVK_GRAVE;
     }
 
-    //0-9, A-Z
-    if (key >= 0x30 && key <= 0x5A){
-        return (portableVKey) key;
+    //A-Z
+    if (qtkey >= Qt::Key_A && qtkey <= Qt::Key_Z){
+        return (portableVKey) qtkey;
     }
 
     return PVK_UNKNOWN; // den vrethike annalogo key
-
 }
 
 int Keyboard::convertPortableKeyToLocal(portableVKey portableKey)
 {
-        switch (portableKey)
-        {
-        case portableVKey::PVK_EQUAL:
-    return XK_equal;
-    break;
-        case portableVKey::PVK_MINUS:
-            return XK_minus;
-            break;
-
-        case portableVKey::PVK_RIGHT_BRACKET:
-    return XK_bracketright;
-    break;
-        case portableVKey::PVK_LEFT_BRACKET:
-    return XK_bracketleft;
-    break;
-        case portableVKey::PVK_QUOTE:
-            return XK_quotedbl;
-            break;
-        case portableVKey::PVK_SHIFT:
-            return XK_Shift_L;
-            break;
-        case portableVKey::PVK_CONTROL:
-            return XK_Control_L;
-            break;
-        case portableVKey::PVK_ALT:
-            return XK_Alt_L;
-            break;
-        case portableVKey::PVK_SEMICOLON:
-    return XK_semicolon;
-    break;
-        case portableVKey::PVK_BACKSLASH:
-            return XK_backslash;
-            break;
-        case portableVKey::PVK_COMMA:
-            return XK_comma;
-            break;
-        case portableVKey::PVK_SLASH:
-            return XK_slash;
-            break;
-        case portableVKey::PVK_PERIOD:
-            return XK_period;
-            break;
-        case portableVKey::PVK_GRAVE:
-            return XK_grave;
-            break;
-
-        case portableVKey::PVK_DECIMAL:
+    switch (portableKey)
+    {
+    case portableVKey::PVK_EQUAL:
+        return XK_equal;
+    case portableVKey::PVK_MINUS:
+        return XK_minus;
+    case portableVKey::PVK_RIGHT_BRACKET:
+        return XK_bracketright;
+    case portableVKey::PVK_LEFT_BRACKET:
+        return XK_bracketleft;
+    case portableVKey::PVK_QUOTE:
+        return XK_quotedbl;
+    case portableVKey::PVK_SHIFT:
+        return XK_Shift_L;
+    case portableVKey::PVK_CONTROL:
+        return XK_Control_L;
+    case portableVKey::PVK_ALT:
+        return XK_Alt_L;
+    case portableVKey::PVK_SEMICOLON:
+        return XK_semicolon;
+    case portableVKey::PVK_BACKSLASH:
+        return XK_backslash;
+    case portableVKey::PVK_COMMA:
+        return XK_comma;
+    case portableVKey::PVK_SLASH:
+        return XK_slash;
+    case portableVKey::PVK_PERIOD:
+        return XK_period;
+    case portableVKey::PVK_GRAVE:
+        return XK_grave;
+    case portableVKey::PVK_DECIMAL:
         return XK_KP_Decimal;
-        break;
-        case portableVKey::PVK_MULTIPLY:
+    case portableVKey::PVK_MULTIPLY:
         return XK_KP_Multiply;
-        break;
-        case portableVKey::PVK_ADD:
+    case portableVKey::PVK_ADD:
         return XK_KP_Add;
-        break;
-        //case kVK_ANSI_KeypadClear:
-        //return portableVKey::PVK_KEYPAD_CLEAR;
-        //break;
-        case portableVKey::PVK_KEYPAD_DIVIDE:
+    case portableVKey::PVK_KEYPAD_DIVIDE:
         return XK_KP_Divide;
-        break;
-        //case kVK_ANSI_KeypadEnter:
-        //return portableVKey::PVK_KEYPAD_ENTER;
-        //break;
-        case portableVKey::PVK_KEYPAD_MINUS:
+    case portableVKey::PVK_KEYPAD_MINUS:
         return XK_KP_Subtract;
+
+    case portableVKey::PVK_NUMPAD0:
+        return XK_KP_0;
+    case portableVKey::PVK_NUMPAD1:
+        return XK_KP_1;
+    case portableVKey::PVK_NUMPAD2:
+        return XK_KP_2;
+    case portableVKey::PVK_NUMPAD3:
+        return XK_KP_3;
+    case portableVKey::PVK_NUMPAD4:
+        return XK_KP_4;
+    case portableVKey::PVK_NUMPAD5:
+        return XK_KP_5;
+    case portableVKey::PVK_NUMPAD6:
+        return XK_KP_6;
+    case portableVKey::PVK_NUMPAD7:
+        return XK_KP_7;
+    case portableVKey::PVK_NUMPAD8:
+        return XK_KP_8;
+    case portableVKey::PVK_NUMPAD9:
+        return XK_KP_9;
+
+    case portableVKey::PVK_RETURN:
+        return XK_Return;
+    case portableVKey::PVK_TAB:
+        return XK_Tab;
+    case portableVKey::PVK_SPACE:
+        return XK_space;
+    case portableVKey::PVK_BACK:
+        return XK_BackSpace;
+    case portableVKey::PVK_ESCAPE:
+        return XK_Escape;
+    case portableVKey::PVK_CAPSLOCK:
+        return XK_Caps_Lock;
+
+    case portableVKey::PVK_VOLUME_UP:
+        return XF86XK_AudioRaiseVolume;
+    case portableVKey::PVK_VOLUME_DOWN:
+        return XF86XK_AudioLowerVolume;
+    case portableVKey::PVK_VOLUME_MUTE:
+        return XF86XK_AudioMute;
+
+    case portableVKey::PVK_F1:
+        return XK_F1;
+    case portableVKey::PVK_F2:
+        return XK_F2;
+    case portableVKey::PVK_F3:
+        return XK_F3;
+    case portableVKey::PVK_F4:
+        return XK_F4;
+    case portableVKey::PVK_F5:
+        return XK_F5;
+    case portableVKey::PVK_F6:
+        return XK_F6;
+    case portableVKey::PVK_F7:
+        return XK_F7;
+    case portableVKey::PVK_F8:
+        return XK_F8;
+    case portableVKey::PVK_F9:
+        return XK_F9;
+    case portableVKey::PVK_F10:
+        return XK_F10;
+    case portableVKey::PVK_F11:
+        return XK_F11;
+    case portableVKey::PVK_F12:
+        return XK_F12;
+    case portableVKey::PVK_F13:
+        return XK_F13;
+    case portableVKey::PVK_F14:
+        return XK_F14;
+    case portableVKey::PVK_F15:
+        return XK_F15;
+    case portableVKey::PVK_F16:
+        return XK_F16;
+    case portableVKey::PVK_F17:
+        return XK_F17;
+    case portableVKey::PVK_F18:
+        return XK_F18;
+    case portableVKey::PVK_F19:
+        return XK_F19;
+    case portableVKey::PVK_F20:
+        return XK_F20;
+    case portableVKey::PVK_F21:
+        return XK_F21;
+    case portableVKey::PVK_F22:
+        return XK_F22;
+    case portableVKey::PVK_F23:
+        return XK_F23;
+    case portableVKey::PVK_F24:
+        return XK_F24;
+
+    case portableVKey::PVK_HELP:
+        return XK_Help;
+    case portableVKey::PVK_HOME:
+        return XK_Home;
+    case portableVKey::PVK_PAGE_UP:
+        return XK_Page_Up;
+    case portableVKey::PVK_DELETE:
+        return XK_Delete;
+    case portableVKey::PVK_END:
+        return XK_End;
+    case portableVKey::PVK_PAGE_DOWN:
+        return XK_Page_Down;
+
+    case portableVKey::PVK_LEFT:
+        return XK_Left;
+    case portableVKey::PVK_RIGHT:
+        return XK_Right;
+    case portableVKey::PVK_UP:
+        return XK_Up;
+    case portableVKey::PVK_DOWN:
+        return XK_Down;
+    case portableVKey::PVK_NUMLOCK:
+        return XK_Num_Lock;
+    case portableVKey::PVK_INSERT:
+        return XK_Insert;
+    case portableVKey::PVK_LWIN:
+        return XK_Super_L;
+    case portableVKey::PVK_RWIN:
+        return XK_Multi_key;
+
+    case portableVKey::PVK_A:
+    case portableVKey::PVK_B:
+    case portableVKey::PVK_C:
+    case portableVKey::PVK_D:
+    case portableVKey::PVK_E:
+    case portableVKey::PVK_F:
+    case portableVKey::PVK_G:
+    case portableVKey::PVK_H:
+    case portableVKey::PVK_I:
+    case portableVKey::PVK_J:
+    case portableVKey::PVK_K:
+    case portableVKey::PVK_L:
+    case portableVKey::PVK_M:
+    case portableVKey::PVK_N:
+    case portableVKey::PVK_O:
+    case portableVKey::PVK_P:
+    case portableVKey::PVK_Q:
+    case portableVKey::PVK_R:
+    case portableVKey::PVK_S:
+    case portableVKey::PVK_T:
+    case portableVKey::PVK_U:
+    case portableVKey::PVK_V:
+    case portableVKey::PVK_W:
+    case portableVKey::PVK_X:
+    case portableVKey::PVK_Y:
+    case portableVKey::PVK_Z:
+    case portableVKey::PVK_0:
+    case portableVKey::PVK_1:
+    case portableVKey::PVK_2:
+    case portableVKey::PVK_3:
+    case portableVKey::PVK_4:
+    case portableVKey::PVK_5:
+    case portableVKey::PVK_6:
+    case portableVKey::PVK_7:
+    case portableVKey::PVK_8:
+    case portableVKey::PVK_9:
+        return portableKey;
+
+    case PVK_CLEAR:
+    case PVK_SEPARATOR:
+    case PVK_UNKNOWN:
         break;
-        //case kVK_ANSI_KeypadEquals:
-        //return portableVKey::PVK_KEYPAD_EQUALS;
-        //break;
+    }
 
-        case portableVKey::PVK_NUMPAD0:
-            return XK_KP_0;
-            break;
-        case portableVKey::PVK_NUMPAD1:
-            return XK_KP_1;
-            break;
-        case portableVKey::PVK_NUMPAD2:
-            return XK_KP_2;
-            break;
-        case portableVKey::PVK_NUMPAD3:
-            return XK_KP_3;
-            break;
-        case portableVKey::PVK_NUMPAD4:
-            return XK_KP_4;
-            break;
-        case portableVKey::PVK_NUMPAD5:
-            return XK_KP_5;
-            break;
-        case portableVKey::PVK_NUMPAD6:
-            return XK_KP_6;
-            break;
-        case portableVKey::PVK_NUMPAD7:
-            return XK_KP_7;
-            break;
-        case portableVKey::PVK_NUMPAD8:
-            return XK_KP_8;
-            break;
-        case portableVKey::PVK_NUMPAD9:
-            return XK_KP_9;
-            break;
-
-        case portableVKey::PVK_RETURN:
-            return XK_Return;
-            break;
-        case portableVKey::PVK_TAB:
-            return XK_Tab;
-            break;
-        case portableVKey::PVK_SPACE:
-            return XK_space;
-            break;
-        case portableVKey::PVK_BACK:
-            return XK_BackSpace;
-            break;
-        case portableVKey::PVK_ESCAPE:
-            return XK_Escape;
-            break;
-        case portableVKey::PVK_CAPSLOCK:
-            return XK_Caps_Lock;
-            break;
-        case portableVKey::PVK_F17:
-            return XK_F17;
-            break;
-        //case portableVKey::PVK_VOLUME_UP:
-        //    return kVK_VolumeUp;
-        //    break;
-        //case portableVKey::PVK_VOLUME_DOWN:
-        //    return kVK_VolumeDown;
-        //    break;
-        //case portableVKey::PVK_VOLUME_MUTE:
-        //    return kVK_Mute;
-        //    break;
-        case portableVKey::PVK_F18:
-            return XK_F18;
-            break;
-        case portableVKey::PVK_F19:
-            return XK_F19;
-            break;
-        case portableVKey::PVK_F20:
-            return XK_F20;
-            break;
-        case portableVKey::PVK_F5:
-            return XK_F5;
-            break;
-        case portableVKey::PVK_F6:
-            return XK_F6;
-            break;
-        case portableVKey::PVK_F7:
-            return XK_F7;
-            break;
-        case portableVKey::PVK_F3:
-            return XK_F3;
-            break;
-        case portableVKey::PVK_F8:
-            return XK_F8;
-            break;
-        case portableVKey::PVK_F9:
-            return XK_F9;
-            break;
-        case portableVKey::PVK_F11:
-            return XK_F11;
-            break;
-        case portableVKey::PVK_F13:
-            return XK_F13;
-            break;
-        case portableVKey::PVK_F16:
-            return XK_F16;
-            break;
-        case portableVKey::PVK_F14:
-            return XK_F14;
-            break;
-        case portableVKey::PVK_F10:
-            return XK_F10;
-            break;
-        case portableVKey::PVK_F12:
-            return XK_F12;
-            break;
-        case portableVKey::PVK_F15:
-            return XK_F15;
-            break;
-        case portableVKey::PVK_HELP:
-            return XK_Help;
-            break;
-        case portableVKey::PVK_HOME:
-            return XK_Home;
-            break;
-        case portableVKey::PVK_PAGE_UP:
-            return XK_Page_Up;
-            break;
-        case portableVKey::PVK_DELETE:
-            return XK_Delete; // ?
-            break;
-        case portableVKey::PVK_F4:
-            return XK_F4;
-            break;
-        case portableVKey::PVK_END:
-            return XK_End;
-            break;
-        case portableVKey::PVK_F2:
-            return XK_F2;
-            break;
-        case portableVKey::PVK_PAGE_DOWN:
-            return XK_Page_Down;
-            break;
-        case  portableVKey::PVK_F1:
-            return XK_F1;
-            break;
-        case portableVKey::PVK_LEFT:
-            return XK_Left;
-            break;
-        case portableVKey::PVK_RIGHT:
-            return XK_Right;
-            break;
-        case portableVKey::PVK_DOWN:
-            return XK_Down;
-            break;
-        case portableVKey::PVK_UP:
-            return XK_Up;
-            break;
-        case portableVKey::PVK_NUMLOCK:
-        return XK_Num_Lock; //TODO: den paizei
-        break;
-        case portableVKey::PVK_INSERT:
-            return XK_Insert;
-            break;
-        //case portableVKey::PVK_LWIN:
-        //case portableVKey::PVK_RWIN:
-        //    return kVK_Control;
-        //    break;
-        }
-
-        //0-9, A-Z
-        if (portableKey >= 0x30 && portableKey <= 0x5A){
-            return portableKey;
-        }
-
-        return -1; // den vrethike annalogo key
+    return -1; // den vrethike annalogo key
 }
 
 #endif
-


### PR DESCRIPTION
Pressed keys are now identified using only the Qt:Key.

Most keys work but Ubuntu seems to intercept the volume keys