### PR TITLE
Fix build on systems with QtVersion < 5.5

### DIFF
--- a/src/Andama/main.cpp
+++ b/src/Andama/main.cpp
@@ -46,12 +46,14 @@ void myMessageOutput(QtMsgType type, const QMessageLogContext &context, const QS
     case QtDebugMsg:
         txt = QString("Debug: %1 (%2:%3, %4)").arg(localMsg.constData()).arg(context.file).arg(context.line).arg(context.function);
         fprintf(stderr, "Debug: %s (%s:%u, %s)\n", localMsg.constData(), context.file, context.line, context.function);
-        break;  
+        break;
         //TODO: For some reason QtInfoMsg is not declared in Qt 5.7.1 for Mac OS
 #ifndef Q_OS_MAC
+#if QT_VERSION >= 0x050500
     case QtInfoMsg:
         txt = QString("Info: %1 (%2:%3, %4)").arg(localMsg.constData()).arg(context.file).arg(context.line).arg(context.function);
         fprintf(stderr, "Info: %s (%s:%u, %s)\n", localMsg.constData(), context.file, context.line, context.function);
+#endif
 #endif
     case QtWarningMsg:
         txt = QString("Warning: %1 (%2:%3, %4)").arg(localMsg.constData()).arg(context.file).arg(context.line).arg(context.function);


### PR DESCRIPTION
Only use QtInfoMsg if using Qt5.5 or later.

This fixes build on Ubuntu 14.04